### PR TITLE
Add .gitignore file to create module script

### DIFF
--- a/scripts/create-module.sh
+++ b/scripts/create-module.sh
@@ -18,6 +18,13 @@ BASE_PATH="../projects/$MODULE_NAME"
 echo "Creating directories..."
 mkdir -p "$BASE_PATH"/{abis,functions}
 
+# Create .gitignore
+
+echo "Creating .gitignore..."
+cat > "$BASE_PATH/.gitignore" << EOF
+node_modules
+EOF
+
 # Create package.json
 echo "Creating package.json..."
 cat > "$BASE_PATH/package.json" << EOF


### PR DESCRIPTION
Hey,

When running the `create_module.sh` script, it initializes the repo, but doesn't create a `.gitignore` file, so whenever you commit it includes `node_modules`.

I modified the script so it does include it